### PR TITLE
[Problem-1857][ImXPAD] Fix response time on get status

### DIFF
--- a/include/imXpadClient.h
+++ b/include/imXpadClient.h
@@ -64,7 +64,7 @@ public:
 	std::string getErrorMessage() const;
 	std::vector<std::string> getDebugMessages() const;
     int getChar();
-    void sendCustomWait(const std::string& cmd, std::string& value);
+    void sendWaitCustom(const std::string& cmd, std::string& value);
 
     int m_skt;							// socket for commands */
 

--- a/include/imXpadClient.h
+++ b/include/imXpadClient.h
@@ -64,6 +64,7 @@ public:
 	std::string getErrorMessage() const;
 	std::vector<std::string> getDebugMessages() const;
     int getChar();
+    void sendCustomWait(const std::string& cmd, std::string& value);
 
     int m_skt;							// socket for commands */
 

--- a/src/imXpadCamera.cpp
+++ b/src/imXpadCamera.cpp
@@ -348,7 +348,8 @@ void Camera::getStatus(XpadStatus& status)
 	unsigned short pos;
 	cmd << "GetDetectorStatus";
 
-	m_xpad_alt->sendWait(cmd.str(), str);
+	//m_xpad_alt->sendWait(cmd.str(), str);
+	m_xpad_alt->sendCustomWait(cmd.str(), str);
 	pos = str.find(".");
 	string state = str.substr (0, pos);
 	if (state == "Idle")
@@ -376,6 +377,7 @@ void Camera::getStatus(XpadStatus& status)
 		status.state = XpadStatus::Resetting;
 	}
 	m_state.state = status.state;
+	std::cout << "Result status : " << state << std::endl;
 	DEB_TRACE() << "XpadStatus.state is [" << status.state << "]";
 
 	DEB_TRACE() << "********** Outside of Camera::getStatus ***********";

--- a/src/imXpadCamera.cpp
+++ b/src/imXpadCamera.cpp
@@ -348,7 +348,7 @@ void Camera::getStatus(XpadStatus& status)
 	unsigned short pos;
 	cmd << "GetDetectorStatus";
 
-	m_xpad_alt->sendCustomWait(cmd.str(), str);
+	m_xpad_alt->sendWaitCustom(cmd.str(), str);
 	pos = str.find(".");
 	string state = str.substr (0, pos);
 	if (state == "Idle")
@@ -376,7 +376,6 @@ void Camera::getStatus(XpadStatus& status)
 		status.state = XpadStatus::Resetting;
 	}
 	m_state.state = status.state;
-	std::cout << "Result status : " << state << std::endl;
 	DEB_TRACE() << "XpadStatus.state is [" << status.state << "]";
 
 	DEB_TRACE() << "********** Outside of Camera::getStatus ***********";

--- a/src/imXpadCamera.cpp
+++ b/src/imXpadCamera.cpp
@@ -348,7 +348,6 @@ void Camera::getStatus(XpadStatus& status)
 	unsigned short pos;
 	cmd << "GetDetectorStatus";
 
-	//m_xpad_alt->sendWait(cmd.str(), str);
 	m_xpad_alt->sendCustomWait(cmd.str(), str);
 	pos = str.find(".");
 	string state = str.substr (0, pos);

--- a/src/imXpadClient.cpp
+++ b/src/imXpadClient.cpp
@@ -50,6 +50,7 @@
 #include "lima/ThreadUtils.h"
 #include "lima/Exceptions.h"
 #include "lima/Debug.h"
+#include <algorithm>
 
 //static char errorMessage[1024];
 
@@ -154,16 +155,11 @@ void XpadClient::sendCustomWait(const string& cmd, string& value)
     }
 
     value = m_rd_buff;
-    value.erase(0,3);
-    // int pos = test.find(".");
-    // test = test.substr (0, pos);
-    // std::cout << "Result test : " << test << std::endl;
-    //value = m_rd_buff;
-    // if (waitForResponse(value) < 0) 
-    // {
-    //     THROW_HW_ERROR(Error) << "Waiting for response from server";
-    // }
-    //waitForResponse(value);
+    std::string special_chars("\"*> ");
+    for(int i = 0; i < special_chars.length(); ++i)
+    {
+        value.erase(std::remove(value.begin(), value.end(), special_chars[i]), value.end());
+    }
 }
 
 void XpadClient::sendNoWait(string cmd) {

--- a/src/imXpadClient.cpp
+++ b/src/imXpadClient.cpp
@@ -138,6 +138,33 @@ void XpadClient::sendWait(string cmd, string& value) {
     }
 }
 
+void XpadClient::sendCustomWait(const string& cmd, string& value)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_TRACE() << "sendCustomWait(" << cmd << ")";
+
+    if( send(m_skt , cmd.c_str() , strlen(cmd.c_str()) , 0) < 0)
+    {
+        THROW_HW_ERROR(Error) << "Send command to server failed.";
+    }
+
+    if( recv(m_skt , m_rd_buff , RD_BUFF , 0) < 0)
+    {
+       THROW_HW_ERROR(Error) << "Receive from server failed.";
+    }
+
+    value = m_rd_buff;
+    value.erase(0,3);
+    // int pos = test.find(".");
+    // test = test.substr (0, pos);
+    // std::cout << "Result test : " << test << std::endl;
+    //value = m_rd_buff;
+    // if (waitForResponse(value) < 0) 
+    // {
+    //     THROW_HW_ERROR(Error) << "Waiting for response from server";
+    // }
+    //waitForResponse(value);
+}
 
 void XpadClient::sendNoWait(string cmd) {
     DEB_MEMBER_FUNCT();

--- a/src/imXpadClient.cpp
+++ b/src/imXpadClient.cpp
@@ -139,7 +139,7 @@ void XpadClient::sendWait(string cmd, string& value) {
     }
 }
 
-void XpadClient::sendCustomWait(const string& cmd, string& value)
+void XpadClient::sendWaitCustom(const string& cmd, string& value)
 {
     DEB_MEMBER_FUNCT();
     DEB_TRACE() << "sendCustomWait(" << cmd << ")";


### PR DESCRIPTION
Create a custom sendWait method to manage status string buffer retuned by Xpad server

- Sending command directly to Xpad server and receive string status response
- Remove ", >, *, and blank space from string to get status informations